### PR TITLE
Reusing http connections are buggy with versions before Android 4.1

### DIFF
--- a/app/src/main/java/at/bitfire/cadroid/ConnectionInfo.java
+++ b/app/src/main/java/at/bitfire/cadroid/ConnectionInfo.java
@@ -13,6 +13,8 @@ import java.security.cert.X509Certificate;
 import lombok.Cleanup;
 import lombok.Getter;
 import lombok.Setter;
+
+import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.Log;

--- a/app/src/main/java/at/bitfire/cadroid/ConnectionInfo.java
+++ b/app/src/main/java/at/bitfire/cadroid/ConnectionInfo.java
@@ -27,13 +27,13 @@ import javax.net.ssl.X509TrustManager;
 public class ConnectionInfo implements Parcelable {
 	private final static String TAG = "cadroid.Fetch";
 	
-	ConnectionInfo() { }
+	private ConnectionInfo() { }
 
 	// host name in URL
 	@Getter @Setter private String hostName;
 	
 	// was there an exception while fetching the certificate?
-	@Getter Exception exception;
+	@Getter private Exception exception;
 	ConnectionInfo(Exception exception) { this.exception = exception; }
 	
 	// certificate details
@@ -71,7 +71,7 @@ public class ConnectionInfo implements Parcelable {
 			@Cleanup InputStream in = urlConnection.getInputStream();
 
 			// read one byte to make sure the connection has been established
-			@SuppressWarnings("unused")
+			//noinspection UnusedAssignment
 			int c = in.read();
 		} catch(IOException e) {
 			String httpStatus = urlConnection.getHeaderField(null);


### PR DESCRIPTION
applies for versions before Android 4.1 (API level 16) and poor server configuration

see https://github.com/bitfireAT/cadroid/issues/18